### PR TITLE
un-include nil role_aggregates in details list returned from explain_role_aggregates_for

### DIFF
--- a/app/models/permission_group.rb
+++ b/app/models/permission_group.rb
@@ -50,7 +50,6 @@ class PermissionGroup < ActiveRecord::Base
         permission_ls_groups.each do |plg|
             ra = plg.lime_survey.role_aggregate
             unless plg.ready_for_use?
-                details.push([ra, 'Permission ls group not ready for use'])
                 result.delete ra
                 next
             end

--- a/app/models/permission_group.rb
+++ b/app/models/permission_group.rb
@@ -50,6 +50,9 @@ class PermissionGroup < ActiveRecord::Base
         permission_ls_groups.each do |plg|
             ra = plg.lime_survey.role_aggregate
             unless plg.ready_for_use?
+                unless ra.nil?
+                    details.push([ra.lime_survey_title, 'Permission ls group not ready for use'])
+                end
                 result.delete ra
                 next
             end


### PR DESCRIPTION
fixes #15 

grep didn't produce any obvious reason for these nil `ra`s to be included outside of completeness.